### PR TITLE
Correção da deleção dos satélites

### DIFF
--- a/sinsp.serve/sinsp/src/main/java/com/tcc/sinsp/controller/SatellitesController.java
+++ b/sinsp.serve/sinsp/src/main/java/com/tcc/sinsp/controller/SatellitesController.java
@@ -3,6 +3,8 @@ package com.tcc.sinsp.controller;
 import java.util.List;
 import java.util.Optional;
 
+import com.tcc.sinsp.model.Measures;
+import com.tcc.sinsp.repository.MeasuresRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -36,7 +38,9 @@ public class SatellitesController {
 	private final ModulesRepository mRep;
 	@Autowired
 	private final ProfilesRepository pRep;
-	
+	@Autowired
+	private final MeasuresRepository measuresRepository;
+
 	private final LogsController lCon;
 	    
     @PostMapping
@@ -92,12 +96,16 @@ public class SatellitesController {
 	    @ResponseStatus(HttpStatus.NO_CONTENT)
 	    public void deletePost(@PathVariable Integer id) throws Exception {
 	    	
-	    	Satellites satellite = repository.findById(id).orElseThrow(() -> new Exception("Delete failed"));
-	    	Logs log = new Logs();
-	     	  log.setMessage(
-	 				"Satellite " + satellite.getSatellite_name() + " has been deleted");
-	 	      lCon.save(log);
-	    	 repository.delete(satellite);
+			Satellites satellite = repository.findById(id).orElseThrow(() -> new Exception("Delete failed"));
+			Logs log = new Logs();
+		  	log.setMessage(
+				"Satellite " + satellite.getSatellite_name() + " has been deleted");
+		  	lCon.save(log);
+
+			List<Measures> measures = measuresRepository.findAllBySatellite(satellite);
+			measuresRepository.deleteAll(measures);
+
+		 	repository.delete(satellite);
 	    }
 	    
 	  }

--- a/sinsp.serve/sinsp/src/main/java/com/tcc/sinsp/model/Measures.java
+++ b/sinsp.serve/sinsp/src/main/java/com/tcc/sinsp/model/Measures.java
@@ -2,17 +2,7 @@ package com.tcc.sinsp.model;
 
 import java.util.Date;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.SequenceGenerator;
-import javax.persistence.Table;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
+import javax.persistence.*;
 
 
 import org.hibernate.annotations.CreationTimestamp;
@@ -44,11 +34,11 @@ public class Measures {
 	  @Column(name="sample_time")
 	  @Temporal(TemporalType.TIMESTAMP)
 	  private Date sample_time;
-	  @ManyToOne
+	  @ManyToOne(cascade = {CascadeType.MERGE, CascadeType.PERSIST})
 	  @JoinColumn(name="satellites_id")
 	  @JsonIgnore
 	  private Satellites satellite;
-	  @ManyToOne
+	  @ManyToOne(cascade = {CascadeType.MERGE, CascadeType.PERSIST})
 	  @JoinColumn(name="modules_id")
 	  @JsonIgnore
 	  private Modules module;

--- a/sinsp.serve/sinsp/src/main/java/com/tcc/sinsp/model/Satellites.java
+++ b/sinsp.serve/sinsp/src/main/java/com/tcc/sinsp/model/Satellites.java
@@ -38,13 +38,13 @@ public class Satellites {
 	  @Column(name="satellite_name", nullable=false)
 	  private String satellite_name;
 	  @ManyToMany(fetch = FetchType.LAZY,
-		        cascade ={CascadeType.REMOVE})
+		        cascade ={CascadeType.MERGE, CascadeType.PERSIST})
 	  @JoinTable(name="satellites_responsible",
       joinColumns=@JoinColumn(name="satellites_id"),
       inverseJoinColumns=@JoinColumn(name="responsible_id"))
 	  private List<Profiles> responsible;
 	  @ManyToMany(fetch = FetchType.LAZY,
-		        cascade ={CascadeType.REMOVE})
+		        cascade ={CascadeType.MERGE, CascadeType.PERSIST})
 	  @JoinTable(name="satellites_modules",
       joinColumns=@JoinColumn(name="satellites_id"),
       inverseJoinColumns=@JoinColumn(name="modules_id"))

--- a/sinsp.serve/sinsp/src/main/java/com/tcc/sinsp/repository/MeasuresRepository.java
+++ b/sinsp.serve/sinsp/src/main/java/com/tcc/sinsp/repository/MeasuresRepository.java
@@ -3,6 +3,7 @@ package com.tcc.sinsp.repository;
 
 import java.util.List;
 
+import com.tcc.sinsp.model.Satellites;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -41,5 +42,5 @@ public interface MeasuresRepository extends JpaRepository<Measures,Long> {
 			  Pageable pageable
 			  ); 
 	  
-	  
+	  List<Measures> findAllBySatellite(Satellites sat);
 }


### PR DESCRIPTION
Essa correção visa atacar o bug que impedia a deleção dos satélites quando havia medições atreladas ao mesmo. A estratégia escolhia foi, antes de deletar o satélite, resgatar e deletar todas as medições vinculadas ao mesmo e só depois efetivar a remoção.